### PR TITLE
feat(Admin): automatically clear StoryRef cache

### DIFF
--- a/app/Domains/Admin/Filament/Resources/StoryRef/AudienceResource/Pages/CreateAudience.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/AudienceResource/Pages/CreateAudience.php
@@ -13,4 +13,9 @@ class CreateAudience extends CreateRecord
     {
         return $this->getResource()::getUrl('index');
     }
+
+    protected function afterCreate(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/AudienceResource/Pages/EditAudience.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/AudienceResource/Pages/EditAudience.php
@@ -8,4 +8,9 @@ use Filament\Resources\Pages\EditRecord;
 class EditAudience extends EditRecord
 {
     protected static string $resource = AudienceResource::class;
+
+    protected function afterSave(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/CopyrightResource/Pages/CreateCopyright.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/CopyrightResource/Pages/CreateCopyright.php
@@ -13,4 +13,6 @@ class CreateCopyright extends CreateRecord
     {
         return $this->getResource()::getUrl('index');
     }
+
+    
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/CopyrightResource/Pages/CreateCopyright.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/CopyrightResource/Pages/CreateCopyright.php
@@ -14,5 +14,8 @@ class CreateCopyright extends CreateRecord
         return $this->getResource()::getUrl('index');
     }
 
-    
+    protected function afterCreate(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/CopyrightResource/Pages/EditCopyright.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/CopyrightResource/Pages/EditCopyright.php
@@ -8,4 +8,10 @@ use Filament\Resources\Pages\EditRecord;
 class EditCopyright extends EditRecord
 {
     protected static string $resource = CopyrightResource::class;
+    
+
+    protected function afterSave(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/FeedbackResource/Pages/CreateFeedback.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/FeedbackResource/Pages/CreateFeedback.php
@@ -13,4 +13,9 @@ class CreateFeedback extends CreateRecord
     {
         return $this->getResource()::getUrl('index');
     }
+
+    protected function afterCreate(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/FeedbackResource/Pages/EditFeedback.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/FeedbackResource/Pages/EditFeedback.php
@@ -8,4 +8,9 @@ use Filament\Resources\Pages\EditRecord;
 class EditFeedback extends EditRecord
 {
     protected static string $resource = FeedbackResource::class;
+
+    protected function afterSave(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/GenreResource/Pages/CreateGenre.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/GenreResource/Pages/CreateGenre.php
@@ -13,4 +13,9 @@ class CreateGenre extends CreateRecord
     {
         return $this->getResource()::getUrl('index');
     }
+
+    protected function afterCreate(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/GenreResource/Pages/EditGenre.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/GenreResource/Pages/EditGenre.php
@@ -8,4 +8,9 @@ use Filament\Resources\Pages\EditRecord;
 class EditGenre extends EditRecord
 {
     protected static string $resource = GenreResource::class;
+
+    protected function afterSave(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/StatusResource/Pages/CreateStatus.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/StatusResource/Pages/CreateStatus.php
@@ -13,4 +13,9 @@ class CreateStatus extends CreateRecord
     {
         return $this->getResource()::getUrl('index');
     }
+
+    protected function afterCreate(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/StatusResource/Pages/EditStatus.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/StatusResource/Pages/EditStatus.php
@@ -8,4 +8,9 @@ use Filament\Resources\Pages\EditRecord;
 class EditStatus extends EditRecord
 {
     protected static string $resource = StatusResource::class;
+
+    protected function afterSave(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/TriggerWarningResource/Pages/CreateTriggerWarning.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/TriggerWarningResource/Pages/CreateTriggerWarning.php
@@ -12,5 +12,10 @@ class CreateTriggerWarning extends CreateRecord
     protected function getRedirectUrl(): string
     {
         return $this->getResource()::getUrl('index');
+    }   
+
+    protected function afterCreate(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
     }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/TriggerWarningResource/Pages/EditTriggerWarning.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/TriggerWarningResource/Pages/EditTriggerWarning.php
@@ -8,4 +8,9 @@ use Filament\Resources\Pages\EditRecord;
 class EditTriggerWarning extends EditRecord
 {
     protected static string $resource = TriggerWarningResource::class;
+
+    protected function afterSave(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/TypeResource/Pages/CreateType.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/TypeResource/Pages/CreateType.php
@@ -13,4 +13,9 @@ class CreateType extends CreateRecord
     {
         return $this->getResource()::getUrl('index');
     }
+
+    protected function afterCreate(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/Admin/Filament/Resources/StoryRef/TypeResource/Pages/EditType.php
+++ b/app/Domains/Admin/Filament/Resources/StoryRef/TypeResource/Pages/EditType.php
@@ -8,4 +8,9 @@ use Filament\Resources\Pages\EditRecord;
 class EditType extends EditRecord
 {
     protected static string $resource = TypeResource::class;
+
+    protected function afterSave(): void
+    {
+        app(StoryRefLookupService::class)->clearCache();
+    }
 }

--- a/app/Domains/StoryRef/Private/Services/StoryRefCache.php
+++ b/app/Domains/StoryRef/Private/Services/StoryRefCache.php
@@ -386,4 +386,15 @@ class StoryRefCache
     {
         $this->cache->forget('storyref:trigger_warnings:active-ordered');
     }
+	
+	public function clearAll(): void
+	{
+		$this->clearTypes();
+		$this->clearAudiences();
+		$this->clearCopyrights();
+		$this->clearGenres();
+		$this->clearStatuses();
+		$this->clearFeedbacks();
+		$this->clearTriggerWarnings();
+	}
 }

--- a/app/Domains/StoryRef/Private/Services/StoryRefLookupService.php
+++ b/app/Domains/StoryRef/Private/Services/StoryRefLookupService.php
@@ -229,4 +229,9 @@ class StoryRefLookupService
         }
         return $this->cache->feedbackIdBySlug($slug);
     }
+	
+	public function clearCache(): void
+	{
+		$this->cache->clearAll();
+	}
 }


### PR DESCRIPTION
Invalidate cache automatically when creating or editing records in Audience, Copyright, Feedback, Genre, Status, and Trigger Warnings (TW).

This ensures that the UI always reflects the latest referential data without waiting for the cache to expire.